### PR TITLE
fixed c++ linker issue

### DIFF
--- a/include/oggz/oggz.h
+++ b/include/oggz/oggz.h
@@ -37,12 +37,13 @@
 #include <sys/types.h>
 
 #include <ogg/ogg.h>
-#include <oggz/oggz_constants.h>
-#include <oggz/oggz_table.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <oggz/oggz_constants.h>
+#include <oggz/oggz_table.h>
 
 /** \mainpage
  *


### PR DESCRIPTION
When compiling anything that uses liboggz as c++ (e.g. g++ or clang++) instead of c (e.g. gcc or clang), there is a linker error
```
/usr/bin/ld: /tmp/ccBio1yu.o: in function `oddata_new()':
demo.c:(.text+0x148): undefined reference to `oggz_table_new()'
/usr/bin/ld: demo.c:(.text+0x173): undefined reference to `oggz_table_new()'
/usr/bin/ld: /tmp/ccBio1yu.o: in function `oddata_delete(ODData*)':
demo.c:(.text+0x20d): undefined reference to `oggz_table_delete(void*)'
/usr/bin/ld: demo.c:(.text+0x21d): undefined reference to `oggz_table_delete(void*)'
collect2: error: ld returned 1 exit status
```
The reason for this error is that `extern "C" {` does not capture declarations made in `oggz_constants.h` and `oggz_table.h`. This can easily be fixed by moving the `extern "C" {` block up a few lines.